### PR TITLE
Change select.h to time.h in MPWCommandFilter.m

### DIFF
--- a/Stsh/Classes/MPWCommandFilter.m
+++ b/Stsh/Classes/MPWCommandFilter.m
@@ -12,7 +12,7 @@
 #import "MPWCommandFilter.h"
 #import "MPWShellProcess.h"
 #import "MPWUpcaseFilter.h"
-#include <sys/select.h>
+#include <sys/time.h>
 
 
 @interface NSFileHandle(isDataAvailable)


### PR DESCRIPTION
While building _stsh_ with Xcode 12.1, I received the following errors in the _MPWCommandFilter.m_ _isDataAvailable_ method:
"Declaration of 'select' must be imported from module 'Darwin.POSIX.sys.time' before it is required"
"Implicit declaration of function 'select' is invalid in C99"

Using _<sys/time.h>_ instead of _<sys/select.h>_ fixes this and allows the build to happen.